### PR TITLE
Support self-hosted usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,9 @@ class QuickChart {
     if (!this.isValid()) {
       throw new Error('You must call setConfig before getUrl');
     }
+    if (this.host !== 'quickchart.io') {
+      throw new Error('Short URLs must use quickchart.io host'); 
+    }
 
     const resp = await axios.post(`${this.baseUrl}/chart/create`, this.getPostData());
     if (resp.status !== 200) {

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ class QuickChart {
       throw new Error('You must call setConfig before getUrl');
     }
 
-    const resp = await axios.post('https://quickchart.io/chart/create', this.getPostData());
+    const resp = await axios.post(`${this.baseUrl}/chart/create`, this.getPostData());
     if (resp.status !== 200) {
       throw `Bad response code ${resp.status} from chart shorturl endpoint`;
     } else if (!resp.data.success) {
@@ -116,7 +116,7 @@ class QuickChart {
       throw new Error('You must call setConfig before getUrl');
     }
 
-    const resp = await axios.post('https://quickchart.io/chart', this.getPostData(), {
+    const resp = await axios.post(`${this.baseUrl}/chart`, this.getPostData(), {
       responseType: 'arraybuffer',
     });
     if (resp.status !== 200) {


### PR DESCRIPTION
Use `this.baseUrl` to allow for querying self-hosted versions of quickchart